### PR TITLE
change StringToHGlobalAnsi to StringToCoTaskMemUTF8 to enrich supported keycode range

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,3 +14,6 @@ I am not a .NET dev and I learned just enough to accomplish what I set out to do
 - Now exports native shared libraries using built-in .NET functionality rather than 3rd party DllEXport package
 - Added GitHub action which builds a .dll for Windows _and_ a .so for Linux
 - Includes ink-runtime-engine.dll file locally rather than relying on package
+
+## Update by DOKTOR:
+Changed `Marshal.StringToHGlobalAnsi` to `Marshal.StringToCoTaskMemUTF8` to support UTF-8

--- a/README.md
+++ b/README.md
@@ -15,5 +15,5 @@ I am not a .NET dev and I learned just enough to accomplish what I set out to do
 - Added GitHub action which builds a .dll for Windows _and_ a .so for Linux
 - Includes ink-runtime-engine.dll file locally rather than relying on package
 
-## Update by DOKTOR:
+### Update by [@IAMDOKTOR](https://github.com/IAMDOKTOR):
 Changed `Marshal.StringToHGlobalAnsi` to `Marshal.StringToCoTaskMemUTF8` to support UTF-8

--- a/src/GMInk/GMInk.cs
+++ b/src/GMInk/GMInk.cs
@@ -36,7 +36,7 @@ namespace GMWolf.GMInk
         public static unsafe char* Continue()
         {
             var result = story?.Continue() ?? "";
-            return (char*)Marshal.StringToHGlobalAnsi(result);
+            return (char*)Marshal.StringToCoTaskMemUTF8(result);
         }
 
 
@@ -51,7 +51,7 @@ namespace GMWolf.GMInk
         public static unsafe char* CurrentChoice(double i)
         {
             var result = story?.currentChoices?[(int)i]?.text ?? "";
-            return (char*)Marshal.StringToHGlobalAnsi(result);
+            return (char*)Marshal.StringToCoTaskMemUTF8(result);
         }
 
 
@@ -66,7 +66,7 @@ namespace GMWolf.GMInk
         public static unsafe char* SaveState()
         {
             var result = story?.state.ToJson() ?? "";
-            return (char*)Marshal.StringToHGlobalAnsi(result);
+            return (char*)Marshal.StringToCoTaskMemUTF8(result);
         }
 
 
@@ -102,7 +102,7 @@ namespace GMWolf.GMInk
             {
                 result = "";
             }
-            return (char*)Marshal.StringToHGlobalAnsi(result);
+            return (char*)Marshal.StringToCoTaskMemUTF8(result);
         }
 
         [UnmanagedCallersOnly(EntryPoint = "TagForContentAtPathCount", CallConvs = new[] {typeof(System.Runtime.CompilerServices.CallConvCdecl)})]
@@ -117,7 +117,7 @@ namespace GMWolf.GMInk
         {
             var pathString = Marshal.PtrToStringUTF8((IntPtr)path) ?? "";
             var result = story?.TagsForContentAtPath(pathString)?[(int)i] ?? "";
-            return (char*)Marshal.StringToHGlobalAnsi(result);
+            return (char*)Marshal.StringToCoTaskMemUTF8(result);
         }
 
         [UnmanagedCallersOnly(EntryPoint = "GlobalTagCount", CallConvs = new[] {typeof(System.Runtime.CompilerServices.CallConvCdecl)})]
@@ -130,7 +130,7 @@ namespace GMWolf.GMInk
         public static unsafe char* GlobalTag(double i)
         {
             var result = story?.globalTags?[(int)i] ?? "";
-            return (char*)Marshal.StringToHGlobalAnsi(result);
+            return (char*)Marshal.StringToCoTaskMemUTF8(result);
         }
 
         [UnmanagedCallersOnly(EntryPoint = "ChoosePathString", CallConvs = new[] {typeof(System.Runtime.CompilerServices.CallConvCdecl)})]
@@ -153,7 +153,7 @@ namespace GMWolf.GMInk
         {
             var varString = Marshal.PtrToStringUTF8((IntPtr)var) ?? "";
             var result = (story?.variablesState?[varString] ?? "").ToString() ?? "";
-            return (char*)Marshal.StringToHGlobalAnsi(result);
+            return (char*)Marshal.StringToCoTaskMemUTF8(result);
         }
 
         [UnmanagedCallersOnly(EntryPoint = "VariableSetReal", CallConvs = new[] {typeof(System.Runtime.CompilerServices.CallConvCdecl)})]


### PR DESCRIPTION
This minor change introduces **UTF-8** support.

The original [Marshal.StringToHGlobalAnsi](https://learn.microsoft.com/en-us/dotnet/api/system.runtime.interopservices.marshal.stringtohglobalansi) showed problems supporting Cyrillic symbols, which are crucial for the potential script localization.

Swapping the method with [Marshal.StringToCoTaskMemUTF8](https://learn.microsoft.com/en-us/dotnet/api/system.runtime.interopservices.marshal.stringtohglobalansi) allowed to enable full support of the Gamemaker project "[Decade](https://store.steampowered.com/app/3272360/Decade/)" when reading information from Inkle's exported script files.

This change will allow the developers in other countries to fully rely on `gmink-redux`, due to the direct support of:

- Bulgarian
- Serbian
- Russian
- Ukrainian
- Belarusian

and other languages that may require extended keycode coverage (i.e. Chinese).

For additional context, please feel free to reach out to my discord: **iamdoktor**